### PR TITLE
Fix nil error if dev_name is missing

### DIFF
--- a/lib/nise_bosh/builder.rb
+++ b/lib/nise_bosh/builder.rb
@@ -49,7 +49,7 @@ module NiseBosh
       final_index = File.exists?(final_index_path) ? YAML.load_file(final_index_path)["builds"] : {}
 
       dev_config_path = File.join(config_dir, "dev.yml")
-      dev_name = File.exists?(dev_config_path) ? YAML.load_file(dev_config_path)["dev_name"] : nil
+      dev_name = File.exists?(dev_config_path) ? YAML.load_file(dev_config_path).fetch("dev_name", "") : ""
       dev_index_path = File.join(@options[:repo_dir], "dev_releases", "index.yml")
       dev_index = File.exists?(dev_index_path) ? YAML.load_file(dev_index_path)["builds"] : {}
 


### PR DESCRIPTION
If  dev_name is missing in `#{release}/config/dev.yml`,  then nil into string error occurs.


```
/home/do_cf_nise_bosh_install/nise_bosh/lib/nise_bosh/builder.rb:53:in `join': can't convert nil into String (TypeError)
	from /home/do_cf_nise_bosh_install/nise_bosh/lib/nise_bosh/builder.rb:53:in `initialize_release_file'
	from /home/do_cf_nise_bosh_install/nise_bosh/lib/nise_bosh/builder.rb:10:in `initialize'
	from /home/do_cf_nise_bosh_install/nise_bosh/lib/nise_bosh/runner.rb:79:in `new'
	from /home/do_cf_nise_bosh_install/nise_bosh/lib/nise_bosh/runner.rb:79:in `run'
	from ./bin/nise-bosh:4:in `<main>'
```